### PR TITLE
Tâche #541 : Ouvrir NoBleme aux contributions + déplacer NoBleme sur GitHub

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at bisceglia.eric@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -74,3 +74,84 @@ available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.ht
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq
+
+- - -
+
+# Charte Code de Conduite Contributeurs
+
+## Notre engagement
+
+Dans l'intérêt de favoriser un environnement ouvert et accueillant, nous nous
+engageons, en tant que responsables et en tant que personnes contribuant à ce
+projet, à faire de la participation une expérience exempte de harcèlement pour
+tout le monde, quel que soit le niveau d'expérience, le sexe, l'identité ou
+l'expression de genre, l'orientation sexuelle, le handicap, l'apparence
+personnelle, la taille physique, l'origine ethnique, l'âge, la religion ou la
+nationalité.
+
+## Nos critères
+
+Exemples de comportements qui contribuent à créer un environnement positif :
+
+* l'utilisation d'un langage ouvert et accueillant
+* le respect des différents points de vue et expériences vécues
+* accepter poliment les critiques constructives
+* se concentrer sur ce qui est meilleur pour la communauté
+* faire preuve d'empathie envers les autres membres de la communauté
+
+Exemples de comportements non acceptables :
+
+* l'utilisation de langage ou d'imagerie sexualisés et les avances sexuelles non
+  sollicitées
+* le _trolling_, les commentaires insultants ou désobligeants, et les attaques
+  personnelles ou d'ordre politique
+* le harcèlement en public ou en privé
+* la publication d'informations privées de tierces personnes, telles que des
+  adresses physiques ou électroniques, sans permission explicite
+* toute conduite qui pourrait être raisonnablement considérée comme inappropriée
+  dans le milieu professionnel
+
+## Nos responsabilités
+
+Les responsables du projet doivent clarifier les critères de comportement
+acceptables de ce projet : il est attendu que ces personnes prennent les
+mesures correctives justes comme réponse à tout comportement inacceptable.
+
+Les personnes qui assurent la maintenance du projet ont le droit et la
+responsabilité de supprimer, modifier ou rejeter les commentaires, _commits_,
+code, modifications du wiki, questions et autres contributions qui ne respectent
+pas ce Code de Conduite, ou de bannir temporairement ou définitivement
+quiconque, suite à des comportements jugés inappropriés, menaçants, injurieux,
+ou nuisibles.
+
+## Objectifs
+
+Ce Code de Conduite s'applique à la fois au sein des espaces du projet ainsi que
+dans les espaces publics lorsqu'un individu représente le projet ou sa
+communauté. Font parties des exemples de représentation d'un projet ou d'une
+communauté le fait d'utiliser une adresse email propre au projet, de poster sur
+les réseaux sociaux avec un compte officiel, ou d'intervenir pour représenter le
+projet au cours d'un événement en-ligne ou hors-ligne. La représentation du
+projet pourra être autrement définie et clarifiée par les responsables du
+projet.
+
+## Application
+
+Les cas de comportements abusifs, harcelants ou tout autre comportement
+inacceptable peuvent être signalés en contactant l'équipe du projet à
+[INSÉRER UNE ADRESSE EMAIL]. Toutes les plaintes seront examinées et étudiées
+et se traduiront par une réponse appropriée aux
+circonstances. L'équipe du projet s'engage à garder confidentielles les
+informations de la personne qui remonte un incident. Plus de détails sur
+la politique de mise en application des règles peuvent être publiés séparément.
+
+Les membres du projet qui ne suivent ou qui n'appliquent pas le Code de
+Conduite de bonne foi s'exposent temporairement ou de façon permanente à des
+répercussions définies par d'autres membres de la direction du projet.
+
+## Attribution
+
+Ce Code de Conduite est adapté du
+[Contributor Covenant](https://www.contributor-covenant.org), version 1.4,
+disponible à
+<https://www.contributor-covenant.org/fr/version/1/4/code-of-conduct>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,12 @@
+Contributing to NoBleme.com
+====================
+
+All contributions should be done through a PR on the develop branch.
+
+If your contribution includes a new feature, first discuss it with Bad on the #dev channel of [NoBleme's IRC server](https://nobleme.com/pages/irc/).
+
+- - -
+
 Contribuer à NoBleme.com
 ====================
 
@@ -6,12 +15,3 @@ Pour toute contribution, passez par une PR sur la branche develop.
 Si votre contribution correspond à une tâche existante sur la [liste des tâches](https://nobleme.com/pages/todo/) de NoBleme, précisez le numéro et la description de la tâche dans le nom de votre PR.
 
 Avant d'ajouter des nouveaux features, discutez-en avec Bad sur le canal #dev du [serveur IRC NoBleme](https://nobleme.com/pages/irc/).
-
-- - -
-
-Contributing to NoBleme.com
-====================
-
-All contributions should be done through a PR on the develop branch.
-
-If your contribution includes a new feature, first discuss it with Bad on the #dev channel of [NoBleme's IRC server](https://nobleme.com/pages/irc/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+Contribuer à NoBleme.com
+====================
+
+Pour toute contribution, passez par une PR sur la branche develop.
+
+Si votre contribution correspond à une tâche existante sur la [liste des tâches](https://nobleme.com/pages/todo/) de NoBleme, précisez le numéro et la description de la tâche dans le nom de votre PR.
+
+Avant d'ajouter des nouveaux features, discutez-en avec Bad sur le canal #dev du [serveur IRC NoBleme](https://nobleme.com/pages/irc/).
+
+- - -
+
+Contributing to NoBleme.com
+====================
+
+All contributions should be done through a PR on the develop branch.
+
+If your contribution includes a new feature, first discuss it with Bad on the #dev channel of [NoBleme's IRC server](https://nobleme.com/pages/irc/).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,3 @@
-Code source de NoBleme.com
-====================
-
-Ce dépôt contient le code source de [NoBleme.com](http://nobleme.com).
-
-Il s'agit d'un site commencé en 2005, réalisé en PHP purement procédural, et maintenu à jour régulièrement depuis. Même si le code source a été modernisé tout du long du développement, son cœur est basé sur des techniques anciennes, datant de l'époque de sa création.
-
-Malgré son âge, la codebase a été designée depuis le début pour être lisible: Le code est aéré, il y a des commentaires un peu partout expliquant les cheminements logiques, et les sections des fichiers sont clairement séparées par de gros blocs de commentaires.
-
-Le site est open sourcé dans un but éducatif et coopératif. De plus, la licence utilisée (MIT) est permissive et vous permet de réutiliser du code de NoBleme si vous le désirez, à condition de garder la licence dans votre code.
-
-- - -
-
 NoBleme.com source code
 ====================
 
@@ -21,3 +8,16 @@ The website was started in 2005, developed in purely procedural PHP, and maintai
 Despite its age, the codebase has been designed from the start for readability: The code is well spaced, comments show the logical train of thought of every file, and the code logic is split within files by huge comment blocks.
 
 The website is open sourced for educative and collaborative reasons. Furthermore, the license (MIT) allows you to reuse code from NoBleme if you so desire, as long as you keep the license in your own codebase.
+
+- - -
+
+Code source de NoBleme.com
+====================
+
+Ce dépôt contient le code source de [NoBleme.com](http://nobleme.com).
+
+Il s'agit d'un site commencé en 2005, réalisé en PHP purement procédural, et maintenu à jour régulièrement depuis. Même si le code source a été modernisé tout du long du développement, son cœur est basé sur des techniques anciennes, datant de l'époque de sa création.
+
+Malgré son âge, la codebase a été designée depuis le début pour être lisible: Le code est aéré, il y a des commentaires un peu partout expliquant les cheminements logiques, et les sections des fichiers sont clairement séparées par de gros blocs de commentaires.
+
+Le site est open sourcé dans un but éducatif et coopératif. De plus, la licence utilisée (MIT) est permissive et vous permet de réutiliser du code de NoBleme si vous le désirez, à condition de garder la licence dans votre code.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Ce dépôt contient le code source de [NoBleme.com](http://nobleme.com).
 
 Il s'agit d'un site commencé en 2005, réalisé en PHP purement procédural, et maintenu à jour régulièrement depuis. Même si le code source a été modernisé tout du long du développement, son cœur est basé sur des techniques anciennes, datant de l'époque de sa création.
 
-Malgré son âge, la codebase a été designée depuis le début pour être lisible: Le code est aéré, il y a des commentaires un peu partout expliquant les cheminements logiques, et les sections des fichiers sont clairement séparées par de gros blocs.
+Malgré son âge, la codebase a été designée depuis le début pour être lisible: Le code est aéré, il y a des commentaires un peu partout expliquant les cheminements logiques, et les sections des fichiers sont clairement séparées par de gros blocs de commentaires.
 
-Le site est open sourcé dans un but éducatif. De plus, la licence utilisée (MIT) est permissive et vous permet de réutiliser du code de NoBleme si vous le désirez, à condition de garder la licence dans votre code.
+Le site est open sourcé dans un but éducatif et coopératif. De plus, la licence utilisée (MIT) est permissive et vous permet de réutiliser du code de NoBleme si vous le désirez, à condition de garder la licence dans votre code.
 
 - - -
 
@@ -16,26 +16,8 @@ NoBleme.com source code
 
 This repository contains the source code of [NoBleme.com](http://nobleme.com).
 
-The website was started in 2005, developed in purely procedural PHP, and maintained regularly since. Even though its source code has been modernized throughout the development process, its heart still relies on ancient technology, dating back from its creation.
+The website was started in 2005, developed in purely procedural PHP, and maintained on a regular basis ever since. Even though its source code has been modernized throughout the development process, its heart still relies on ancient technology, dating back from its creation.
 
-Despite its age, the codebase has been designed from the start for readability: The code is well spaced, comments show the logical train of throught of every file.
+Despite its age, the codebase has been designed from the start for readability: The code is well spaced, comments show the logical train of thought of every file, and the code logic is split within files by huge comment blocks.
 
-The website is open sourced for educative reasons. Furthermore, the license (MIT) allows you to reuse code from NoBleme if you so desire, as long as you keep the license in your own codebase.
-
-- - -
-
-Contribuer au code source de NoBleme.com
-====================
-
-Je n'accepte pas les contributions à la source de NoBleme : Si vous proposez une pull request, elle sera refusée. Je tiens à travailler seul dessus, afin d'avoir le contrôle total sur ce que je fais. L'investissement temporel est conséquent, mais j'en assume la responsabilité.
-
-Toutefois, si vous trouvez un problème et voulez proposer une solution, ou si vous avez des propositions d'améliorations, [utilisez le formulaire sur NoBleme](http://nobleme.com/pages/todo/request) ou venez en discuter sur le canal #dev du [serveur IRC de NoBleme](http://nobleme.com/pages/irc/index).
-
-- - -
-
-Contributing to NoBleme.com's source code
-====================
-
-I do not accept contibutions to NoBleme: If you do a pull request, it will be denied. I want to work alone on it, in order to have total control over the direction in which I'm taking things. The time investment is massive, but I'm fine with it.
-
-However, if you do find an issue and want to suggest a solution to it, you can [use the bug report form on NoBleme](http://nobleme.com/pages/todo/request) or contact Bad on [NoBleme's IRC server](http://nobleme.com/pages/irc/index), and your feedback will surely be appreciated.
+The website is open sourced for educative and collaborative reasons. Furthermore, the license (MIT) allows you to reuse code from NoBleme if you so desire, as long as you keep the license in your own codebase.

--- a/cv.php
+++ b/cv.php
@@ -427,7 +427,7 @@ EOD;
         </p>
 
         <p>
-          Le code source de NoBleme est entièrement libre et open source, publié sous une license permissive qui permet de le réutiliser. Il est visible publiquement sur Bitbucket : <a class="gras" href="https://bitbucket.org/EricBisceglia/nobleme.com/overview">voir le code source de NoBleme.com</a><br>
+          Le code source de NoBleme est entièrement libre et open source, publié sous une license permissive qui permet de le réutiliser. Il est visible publiquement sur GitHub : <a class="gras" href="https://github.com/EricBisceglia/NoBleme.com">voir le code source de NoBleme.com</a><br>
           <br>
           Vous trouverez plus d'informations sur les aspects techniques du développement de NoBleme.com et sur mes convictions de développeur en visitant les <a class="gras" href="<?=$chemin?>pages/nobleme/coulisses">coulisses de NoBleme</a>
         </p>
@@ -695,7 +695,7 @@ EOD;
         </p>
 
         <p>
-          NoBleme's source code is entirely free and open source, published under a permissive license that lets you reuse parts of it if you desire. It is publicly available on Bitbucket: <a class="gras" href="https://bitbucket.org/EricBisceglia/nobleme.com/overview">NoBleme.com's source code</a><br>
+          NoBleme's source code is entirely free and open source, published under a permissive license that lets you reuse parts of it if you desire. It is publicly available on GitHub: <a class="gras" href="https://github.com/EricBisceglia/NoBleme.com">NoBleme.com's source code</a><br>
         </p>
 
         <br>

--- a/pages/dev/ircbot.php
+++ b/pages/dev/ircbot.php
@@ -156,7 +156,7 @@ else
 
         <form method="POST">
           <fieldset>
-            <label for="botCommit">URL du commit | <a href="https://bitbucket.org/EricBisceglia/nobleme.com/commits/all">Bitbucket</a></label>
+            <label for="botCommit">URL du commit | <a href="https://github.com/EricBisceglia/NoBleme.com/commits/develop">GitHub</a></label>
             <input id="botCommit" name="botCommit" class="indiv" type="text"><br>
             <br>
             <label for="botCommitTitre">Titre du commit</label>

--- a/pages/dev/maj.php
+++ b/pages/dev/maj.php
@@ -50,7 +50,7 @@ $page_nom = "Administre secrètement le site";
         <h4>Faire une mise à jour</h4>
 
         <p>
-          <input type="checkbox"> Commit les changements et vérifier que le commit ait bien été push dans <a href="https://bitbucket.org/EricBisceglia/nobleme.com/commits/all">le dépôt public</a><br>
+          <input type="checkbox"> Commit les changements et vérifier que le commit ait bien été push dans <a href="https://github.com/EricBisceglia/NoBleme.com/commits/develop">le dépôt public</a><br>
           <input type="checkbox"> Commencer par faire un backup complet du www et du sql du site en production<br>
           <input type="checkbox"> Avant de faire la mise à jour en production, <a href="<?=$chemin?>pages/dev/fermeture">fermer le site au public</a> si nécessaire<br>
           <input type="checkbox"> Aller sur la version en production du site et <a href="<?=$chemin?>pages/dev/sql">faire les requêtes SQL</a> s'il y en a<br>
@@ -68,7 +68,7 @@ $page_nom = "Administre secrètement le site";
         <h4>Après une mise à jour</h4>
 
         <p>
-          <input type="checkbox"> Choper l'url du dernier commit dans <a href="https://bitbucket.org/EricBisceglia/nobleme.com/commits/all">le dépôt public</a> et le partager publiquement sur #dev via <a href="<?=$chemin?>pages/dev/ircbot">le bot IRC</a><br>
+          <input type="checkbox"> Choper l'url du dernier commit dans <a href="https://github.com/EricBisceglia/NoBleme.com/commits/develop">le dépôt public</a> et le partager publiquement sur #dev via <a href="<?=$chemin?>pages/dev/ircbot">le bot IRC</a><br>
           <input type="checkbox"> Archiver les backups du www et du sql et en faire une copie de sauvegarde sur HDD externe<br>
           <input type="checkbox"> Supprimer les requêtes qui ne sont plus nécessaires dans la source de /pages/dev/sql.php<br>
           <input type="checkbox"> Félicitations, la mise à jour est finie et tout s'est bien passé <?=bbcode(":)")?>

--- a/pages/nobleme/coulisses.php
+++ b/pages/nobleme/coulisses.php
@@ -52,12 +52,8 @@ $page_desc  = "Un regard à travers la facade du site, droit dans les entrailles
         <h5>Code source de NoBleme</h5>
 
         <p>
-          Le code source de NoBleme est hébergé dans un dépôt public sur Bitbucket :
+          Le code source de NoBleme est hébergé dans un dépôt public sur GitHub : <a class="gras" href="https://github.com/EricBisceglia/NoBleme.com">NoBleme sur GitHub</a>
         </p>
-
-        <br>
-
-        <button class="button button-outline" onclick="var sourcecode = window.open('https://bitbucket.org/EricBisceglia/nobleme.com/src/', '_blank'); sourcecode.focus;">VOIR LE CODE SOURCE DE NOBLEME</button>
 
         <p>
           Par désir de transparence, l'intégralité du code source de NoBleme est open sourcé : Si vous vous avez des connaissances en développement et que vous vous demandez comment un aspect de NoBleme est géré, vous pouvez trouver la réponse à vos questions dans la source publique du site.
@@ -68,15 +64,11 @@ $page_desc  = "Un regard à travers la facade du site, droit dans les entrailles
         </p>
 
         <p>
-          La source du site est très vieille (le site est dévelopé en continu depuis 2005), et utilise par choix des technologies qui ne sont pas très modernes (PHP procédural sans framework, javascript sans framework, MySQL), mais elle est tout de même modernisée régulièrement afin de rester en concordance technologique avec son temps.
+          La source du site est très vieille (le site est dévelopé en continu depuis 2005), et utilise des technologies qui ne sont pas très modernes (PHP procédural sans framework, javascript sans framework, MySQL), mais elle est tout de même modernisée régulièrement afin de rester en concordance technologique avec son temps. Ce style ancien est un choix : je prends tout simplement plus de plaisir à coder de cette façon.
         </p>
 
         <p>
           L'intégralité du code source est commenté de façon exhaustive, et les commentaires sont faits pour être aussi explicites que possible. Ainsi, même si vous ne maitrisez pas totalement les langages de programmation utilisés, vous devriez quand même pouvoir suivre la logique du code sur n'importe quelle page.
-        </p>
-
-        <p>
-          Le choix de Bitucket pour héberger la source est technologique : Le dépôt de NoBleme est versionné avec <a class="gras" href="https://fr.wikipedia.org/wiki/Mercurial">Mercurial</a> plutôt que git (préférence personnelle), ce qui exclut d'utiliser des sites comme Github qui ne gèrent pas Mercurial. Au moment de la création du dépôt, parmi les sites gratuits qui géraient Mercurial, Bitbucket avait la meilleure infrastructure et le plus de fonctionnalités utiles. Le choix était donc logique.
         </p>
 
         <br>
@@ -85,11 +77,11 @@ $page_desc  = "Un regard à travers la facade du site, droit dans les entrailles
         <h5>Contribuer au code source de NoBleme</h5>
 
         <p>
-          Lorsque je travaille seul sur un projet, ma méthode de développement est très pointilleuse et perfectionniste. Par conséquent, je préfère refuser toutes les contributions à NoBleme, car je risque de toutes les rejeter.
+          Si vous avez repéré un problème dans le code source de NoBleme ou que vous avez des ajouts constructifs à y faire, vous pouvez <a class="gras" href="<?=$chemin?>pages/todo/request?bug">ouvrir un ticket</a> et/ou venir en discuter <a class="gras" href="<?=$chemin?>pages/irc/index">sur IRC</a>.
         </p>
 
         <p>
-          Si vous avez repéré un problème dans le code source de NoBleme ou que vous avez des ajouts constructifs à y faire, vous pouvez <a class="gras" href="<?=$chemin?>pages/todo/request?bug">ouvrir un ticket</a> et/ou venir en discuter <a class="gras" href="<?=$chemin?>pages/irc/index">sur IRC</a>. Même si je rejette les contributions directes, ce type de contributions indirectes est toujours très fortement apprécié.
+          Si jamais vous vous sentez assez courageux pour contribuer directement à NoBleme, le code source du site est ouvert aux contributions du public. Codez vos changements dans votre propre branche, assurez-vous de respecter le style du code déjà existant, faites une <a class="gras" href="https://help.github.com/en/articles/about-pull-requests">pull request</a> sur la branche develop du <a class="gras" href="https://github.com/EricBisceglia/NoBleme.com">dépôt NoBleme sur GitHub</a>, et votre contribution sera acceptée si elle est intéressante ou utile.
         </p>
 
         <br>
@@ -173,7 +165,7 @@ $page_desc  = "Un regard à travers la facade du site, droit dans les entrailles
             Je me sers de temps en temps de <a class="gras" href="https://winscp.net/eng/docs/lang:fr">WinSCP</a> pour transmettre des fichiers
           </li>
           <li>
-           Le <a class="gras" href="https://fr.wikipedia.org/wiki/Logiciel_de_gestion_de_versions">versionnage</a> se fait dans un dépôt <a class="gras" href="https://fr.wikipedia.org/wiki/Mercurial">Mercurial</a> que je gère via <a class="gras" href="https://tortoisehg.bitbucket.io/">TortoiseHg</a>
+           Le <a class="gras" href="https://fr.wikipedia.org/wiki/Logiciel_de_gestion_de_versions">versionnage</a> se fait dans un dépôt <a class="gras" href="https://fr.wikipedia.org/wiki/Git">Git</a> qui est publié sur <a class="gras" href="https://github.com/EricBisceglia/NoBleme.com">GitHub</a>
           </li>
         </ul>
 
@@ -205,12 +197,8 @@ $page_desc  = "Un regard à travers la facade du site, droit dans les entrailles
         <h5>NoBleme's source code</h5>
 
         <p>
-          NoBleme's source code is hosted on a public Bitbucket repository:
+          NoBleme's source code is hosted on a public GitHub repository: <a class="gras" href="https://github.com/EricBisceglia/NoBleme.com">NoBleme on GitHub</a>
         </p>
-
-        <br>
-
-        <button class="button button-outline" onclick="var sourcecode = window.open('https://bitbucket.org/EricBisceglia/nobleme.com/src/', '_blank'); sourcecode.focus;">CLICK TO SEE NOBLEME'S SOURCE CODE</button>
 
         <p>
           NoBleme's source code was made public for transparency reasons: If you happen to be experienced in development and wonder how some of NoBleme's features work, you can find answers to your questions in this public repository.
@@ -221,15 +209,11 @@ $page_desc  = "Un regard à travers la facade du site, droit dans les entrailles
         </p>
 
         <p>
-          The website's source code is rather old in places (development has been ongoing since 2005), and uses technologies that can feel antiquated (procedural PHP without any framework, raw javascript, MySQL), but still gets updated and kept up to date as the technologies it uses evolve over time.
+          The website's source code is rather old in places (development has been ongoing since 2005), and uses technologies that can feel antiquated (procedural PHP without any framework, raw javascript, MySQL), but still gets updated and kept up to date as the technologies it uses evolve over time. Sticking to this older style is a design choice, for the simple reason that I take pleasure in coding like this.
         </p>
 
         <p>
           Every file in the repository is exhaustively commented, but sadly it's all in french. This might make the source code complicated to understand if you're not familiar with the languages used on the website. I am comfortable coding in both french and english, and will pick either depending on the project requirements. Since NoBleme started as a purely french website, I picked french for its documentation.
-        </p>
-
-        <p>
-          The choice of Bitbucket over another website is a technological choice: NoBleme's repository uses <a class="gras" href="https://en.wikipedia.org/wiki/Mercurial">Mercurial</a> rather than git (personal preference), which prevents the use of websites that support only Git (such as Github). Out of the free version control hosting websites that supported Mercurial when I open sourced NoBleme, Bitbucket was the one with the best infrastructure and features, thus the logical choice.
         </p>
 
         <br>
@@ -238,11 +222,11 @@ $page_desc  = "Un regard à travers la facade du site, droit dans les entrailles
         <h5>Contributing to NoBleme's source</h5>
 
         <p>
-          When I work alone on a project, I tend to code in a very pedantic and perfectionist way. This means that most direct code contributions tend to feel improper, and I end up rejecting them all.
+          If you have found an issue in NoBleme's source code or want to do some constructive criticism, you can <a class="gras" href="<?=$chemin?>pages/todo/request?bug">make a proposal</a> and/or come talk about it <a class="gras" href="<?=$chemin?>pages/irc/index">on IRC</a>. Even though I do not accept direct contributions, this kind of indirect contribution through feedback is highly appreciated.
         </p>
 
         <p>
-          If you have found an issue in NoBleme's source code or want to do some constructive criticism, you can <a class="gras" href="<?=$chemin?>pages/todo/request?bug">make a proposal</a> and/or come talk about it <a class="gras" href="<?=$chemin?>pages/irc/index">on IRC</a>. Even though I do not accept direct contributions, this kind of indirect contribution through feedback is highly appreciated.
+          If you feel brave enough to directly contribute to NoBleme's source code, it is open to public contributions. Write your changes in your own branch, make sure you respect the coding style of the already existing code, make a <a class="gras" href="https://help.github.com/en/articles/about-pull-requests">pull request</a> on the develop branch of <a class="gras" href="https://github.com/EricBisceglia/NoBleme.com">NoBleme's repository on GitHub</a>, and your contribution should be accepted if it is interesting or useful.
         </p>
 
         <br>
@@ -326,7 +310,7 @@ $page_desc  = "Un regard à travers la facade du site, droit dans les entrailles
             I sometimes use <a class="gras" href="https://winscp.net/eng/docs/start">WinSCP</a> to transfer files and do backups
           </li>
           <li>
-           <a class="gras" href="https://en.wikipedia.org/wiki/Software_versioning">Versioning</a> is done in a <a class="gras" href="https://en.wikipedia.org/wiki/Mercurial">Mercurial</a> repository which I manage using <a class="gras" href="https://tortoisehg.bitbucket.io/">TortoiseHg</a>
+           <a class="gras" href="https://en.wikipedia.org/wiki/Software_versioning">Versioning</a> is done in a <a class="gras" href="https://en.wikipedia.org/wiki/Git">Git</a> repository which is published on <a class="gras" href="https://github.com/EricBisceglia/NoBleme.com">GitHub</a>
           </li>
         </ul>
 

--- a/pages/todo/request.php
+++ b/pages/todo/request.php
@@ -101,7 +101,7 @@ if($lang == 'FR')
     $trad['bug_soustitre']    = "NoBleme vous remercie d'avance de votre aide";
     $trad['bug_desc']         = <<<EOD
 <p>
-  Si vous avez identifié un problème dans le fonctionnement de NoBleme ou dans son <a class="gras" href="https://bitbucket.org/EricBisceglia/nobleme.com/src/">code source</a>, remplissez le formulaire ci-dessous en détaillant autant que possible la nature du problème que vous avez découvert.
+  Si vous avez identifié un problème dans le fonctionnement de NoBleme ou dans son <a class="gras" href="https://github.com/EricBisceglia/NoBleme.com">code source</a>, remplissez le formulaire ci-dessous en détaillant autant que possible la nature du problème que vous avez découvert.
 </p>
 <p>
   Une fois que <a class="gras" href="{$chemin}pages/user/user?id=1">Bad</a> aura reçu votre rapport de bug, vous recevrez une <a class="gras" href="{$chemin}pages/user/notifications">notification</a> vous informant de l'état du suivi de votre bug. Merci d'avance pour votre contribution à NoBleme !
@@ -160,7 +160,7 @@ else if($lang == 'EN')
     $trad['bug_soustitre']    = "NoBleme thanks you for your help";
     $trad['bug_desc']         = <<<EOD
 <p>
-  If you have found a flaw by using NoBleme or browsing its <a class="gras" href="https://bitbucket.org/EricBisceglia/nobleme.com/src/">source code</a>, please fill up the form below and make sure to detail the issue as much as you can.
+  If you have found a flaw by using NoBleme or browsing its <a class="gras" href="https://github.com/EricBisceglia/NoBleme.com">source code</a>, please fill up the form below and make sure to detail the issue as much as you can.
 </p>
 <p>
   Once <a class="gras" href="{$chemin}pages/user/user?id=1">Bad</a> has read your bug report, you will receive a <a class="gras" href="{$chemin}pages/user/notifications">notification</a> informing you about the status of your bug report. Thanks in advance for your contribution to NoBleme!

--- a/pages/todo/resolu.php
+++ b/pages/todo/resolu.php
@@ -186,7 +186,7 @@ $select_visibilite .= '<option value="0"'.$selected.'>Privé</option>';
             </select><br>
             <br>
 
-            <label for="todo_edit_source">Code source du patch | <a href="https://bitbucket.org/EricBisceglia/nobleme.com/commits/all">Bitbucket</a></label>
+            <label for="todo_edit_source">Code source du patch | <a href="https://github.com/EricBisceglia/NoBleme.com/commits/develop">GitHub</a></label>
             <input id="todo_edit_source" name="todo_edit_source" class="indiv" type="text" value="<?=$todo_source?>"><br>
             <br>
 


### PR DESCRIPTION
Tâche #541 : Ouvrir NoBleme aux contributions + déplacer NoBleme sur GitHub
https://nobleme.com/pages/todo/index?id=541 